### PR TITLE
Correct typo in the Cert Auto Enroll documentation

### DIFF
--- a/xml/security_ad_support.xml
+++ b/xml/security_ad_support.xml
@@ -1359,7 +1359,7 @@
     </step>
     <step>
     <para>
-     For SSSD-joined machines, install <package>samba-gpupdate</package>
+     For SSSD-joined machines, install <package>oddjob-gpupdate</package>
      from <link xlink:href="https://github.com/openSUSE/oddjob-gpupdate"/>.
     </para>
    </step>


### PR DESCRIPTION
### PR creator: Description

This simply corrects a typo in the AD support document.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
